### PR TITLE
Move to `async/.await`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 
 name = "waiter"
+edition = "2021"
 description = "Simple waiter trait for synchronous events"
 version = "0.1.1"
 authors = ["Dmitry Tantsur <divius.inside@gmail.com>"]
@@ -18,3 +19,7 @@ path = "src/lib.rs"
 
 [badges]
 travis-ci = { repository = "dtantsur/rust-waiter" }
+
+[dependencies]
+async-trait = "0.1.58"
+tokio = { version = "1.21.2", features = ["time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "waiter"
 edition = "2021"
 description = "Simple waiter trait for synchronous events"
@@ -13,7 +12,6 @@ license = "MIT/Apache-2.0"
 categories = ["development-tools"]
 
 [lib]
-
 name = "waiter"
 path = "src/lib.rs"
 
@@ -22,4 +20,4 @@ travis-ci = { repository = "dtantsur/rust-waiter" }
 
 [dependencies]
 async-trait = "0.1.58"
-tokio = { version = "1.21.2", features = ["time"] }
+tokio = { version = "1.21.2", default-features = false, features = ["time"] }


### PR DESCRIPTION
Hi,

This PR is made in the context of my other PR ([**#131**]) for `rust-openstack` which aims to move the entire SDK to `async/await`.  

[**#131**]: https://github.com/dtantsur/rust-openstack/pull/131

In this endeavour, the SDK needs to be able to make asynchronous requests within its implementation of `Waiter::poll`.  

So this PR changes the `Waiter` trait methods to be `async` using the `async_trait` attribute.  
It also changes calls to `std::thread::sleep` to be calls to `tokio::time::sleep` instead, to avoid synchronous blocking.  